### PR TITLE
Close lab feature and cancel queue feature

### DIFF
--- a/internal/daemon/adminEvents.go
+++ b/internal/daemon/adminEvents.go
@@ -113,6 +113,12 @@ func (d *daemon) newEvent(c *gin.Context) {
 			return
 		}
 
+		if req.Type == int32(TypeBeginner) {
+			log.Warn().Msg("admin user tried to create an event with beginner type")
+			c.JSON(http.StatusBadRequest, APIResponse{Status: "Beginner events are no longer supported"})
+			return
+		}
+
 		uniqueExercisesList := removeDuplicates(req.ExerciseTags)
 
 		exClientResp, err := d.exClient.GetExerciseByTags(ctx, &eproto.GetExerciseByTagsRequest{Tag: uniqueExercisesList})


### PR DESCRIPTION
Users can now close their lab on command and cancel their place in the queue in case of issues with getting a lab.
This should prevent the need for creating new users in case of errors.

Also disabled beginner events as a lot of issues exists in regards to ophaned labs and overuse of containers